### PR TITLE
add smiles to results.csv

### DIFF
--- a/src/relaxation/save.jl
+++ b/src/relaxation/save.jl
@@ -34,7 +34,7 @@ function write_results_csv(filename, cocktails)
     @info "Writing results to $filename"
     open(filename, "w") do io
         # Write the header
-        println(io, "cocktail_id,fragment_id,peak_id,library_shift,reference_shift,bound_shift,intensity_ratio,intensity_ratio_error,chemical_shift_perturbation,reference_R2,reference_R2_error,bound_R2,bound_R2_error,DeltaR2,DeltaR2_error,reduced_chi2")
+        println(io, "cocktail_id,fragment_id,peak_id,smiles,library_shift,reference_shift,bound_shift,intensity_ratio,intensity_ratio_error,chemical_shift_perturbation,reference_R2,reference_R2_error,bound_R2,bound_R2_error,DeltaR2,DeltaR2_error,reduced_chi2")
         
         for cocktail in cocktails
             for peak in cocktail.peaks
@@ -42,6 +42,7 @@ function write_results_csv(filename, cocktails)
                     peak.cocktail_id,
                     peak.fragment_id,
                     peak.peak_id,
+                    peak.smiles,
                     peak.library_shift,
                     peak.reference_shift,
                     peak.bound_shift,

--- a/src/relaxation/screeningpeaks.jl
+++ b/src/relaxation/screeningpeaks.jl
@@ -44,6 +44,7 @@ function ScreeningPeak(peak::BasicPeak)
     boundspec = peak.boundspec
     peak_id = peak.id
     fragment_id = peak.fragment_id #peak_id[1:end-1]
+    smiles = peak.smiles
     cocktail_id = peak.cocktail_id
     library_shift = peak.library_shift
     reference_shift = peak.ref_shift
@@ -53,6 +54,7 @@ function ScreeningPeak(peak::BasicPeak)
         boundspec,
         peak_id,
         fragment_id,
+        smiles,
         cocktail_id,
         library_shift,
         reference_shift,
@@ -63,6 +65,7 @@ function ScreeningPeak(refspec,
         boundspec,
         peak_id,
         fragment_id,
+        smiles,
         cocktail_id,
         library_shift,
         reference_shift,
@@ -80,6 +83,7 @@ function ScreeningPeak(refspec,
         boundspec,
         peak_id,
         fragment_id,
+        smiles,
         cocktail_id,
         library_shift,
         reference_shift,

--- a/src/relaxation/types.jl
+++ b/src/relaxation/types.jl
@@ -26,6 +26,7 @@ struct ScreeningPeak <: AbstractPeak
     boundspec
     peak_id
     fragment_id
+    smiles
     cocktail_id
     library_shift
     reference_shift


### PR DESCRIPTION
When saving results, results.csv now includes smiles strings that correspond to each of the fragments. 