### PR TITLE
Set canonical URL so Documenter emits a sitemap

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,7 +13,7 @@ makedocs(
         "Home" => "index.md",
     ],
     authors="Chris Waudby",
-    format=Documenter.HTML(),
+    format=Documenter.HTML(; canonical="https://waudbylab.org/NMRScreen.jl/stable/"),
     warnonly=[:missing_docs],
 )
 


### PR DESCRIPTION
## Summary
- The docs site (`waudbylab.org/NMRScreen.jl/`) wasn't being indexed by Google. Root cause: `docs/make.jl` never set a `canonical` URL on `Documenter.HTML(...)`, so Documenter never emitted `<link rel="canonical">` tags or a `sitemap.xml` on deploy — and the versioned doc tree (`dev/`, `stable/`, `vX.Y.Z/` folders) all look like duplicate content to search engines.
- Sets `canonical = "https://waudbylab.org/NMRScreen.jl/stable/"` so the next docs deploy generates canonical tags and a sitemap automatically.

## Test plan
- [ ] Docs CI (`Documenter.yml`) builds successfully on this branch
- [ ] After merge, confirm `stable/index.html` on `gh-pages` has a `<link rel="canonical">` tag and a `sitemap.xml` is generated at the site root

---
_Generated by [Claude Code](https://claude.ai/code/session_018NjmXng5LYsya4ETmAxgga)_