### PR TITLE
Fix CI: run GLMakie tests under Xvfb

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,6 +35,14 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+      - name: Install GLMakie system dependencies (OpenGL, Xvfb)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xorg-dev mesa-utils xvfb libgl1 freeglut3-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev
+      - name: Start virtual framebuffer
+        run: |
+          Xvfb :99 -screen 0 1024x768x24 &
+          echo "DISPLAY=:99" >> $GITHUB_ENV
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1


### PR DESCRIPTION
GLMakie precompiles by initializing GLFW, which fails on headless
GitHub Actions runners with "X11: The DISPLAY environment variable is
missing". Install the OpenGL/X11 dependencies and start a virtual
framebuffer before the Julia test step so DISPLAY is set for the job.